### PR TITLE
Remove ambiguous call to `die`.

### DIFF
--- a/SetupWrapper.hs
+++ b/SetupWrapper.hs
@@ -18,7 +18,7 @@ import Distribution.Text
 
 import System.Environment
 import System.Process
-import System.Exit (ExitCode(..), exitWith)
+import System.Exit (ExitCode(..), exitWith, die)
 import System.FilePath
 import System.Directory
 import qualified Control.Exception as Exception
@@ -88,7 +88,7 @@ setupWrapper setupHsFile = do
       let cabalDep = Dependency (PackageName "Cabal")
                                 (orLaterVersion useCabalVersion)
       case PackageIndex.lookupDependency index cabalDep of
-        []   -> die $ "The package requires Cabal library version "
+        []   -> System.Exit.die $ "The package requires Cabal library version "
                    ++ display useCabalVersion
                    ++ " but no suitable version is installed."
         pkgs -> return $ bestVersion (map fst pkgs)


### PR DESCRIPTION
A `cabal install` build in a clean sandbox (stackage lts-3.0 initialized) using
GHC 7.10.2 lead to following error

```
SetupWrapper.hs:91:17:
Ambiguous occurrence ‘die’
It could refer to either ‘Distribution.Simple.Utils.die’,
imported from ‘Distribution.Simple.Utils’ at
SetupWrapper.hs:8:1-32
or ‘System.Exit.die’,
imported from ‘System.Exit’ at
SetupWrapper.hs:21:1-18
```